### PR TITLE
Removed don't recommended jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,10 +90,6 @@
 			<artifactId>mysql-connector-java</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>commons-dbcp</groupId>
-			<artifactId>commons-dbcp</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 			<version>${guava.version}</version>


### PR DESCRIPTION
As per spring boot documentation http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-connect-to-production-database commons-dbcp is not recommended in production and as we are using spring-boot-starter-data-jpa tomcat-jdbc will be used