### PR TITLE
Removes manual creating of JavaMailSenderImpl

### DIFF
--- a/src/main/java/org/baeldung/spring/AppConfig.java
+++ b/src/main/java/org/baeldung/spring/AppConfig.java
@@ -1,59 +1,16 @@
 package org.baeldung.spring;
 
-import java.util.Properties;
-
 import org.baeldung.security.ActiveUserStore;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.PropertySource;
-import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
-import org.springframework.core.env.Environment;
-import org.springframework.mail.javamail.JavaMailSenderImpl;
 
 @Configuration
-@ComponentScan(basePackages = { "org.baeldung.registration" })
-@PropertySource("classpath:email.properties")
 public class AppConfig {
-    private final Logger LOGGER = LoggerFactory.getLogger(getClass());
-
-    @Autowired
-    private Environment env;
-
     // beans
-
-    @Bean
-    public static PropertySourcesPlaceholderConfigurer propertyPlaceHolderConfigurer() {
-        return new PropertySourcesPlaceholderConfigurer();
-    }
 
     @Bean
     public ActiveUserStore activeUserStore() {
         return new ActiveUserStore();
-    }
-
-    @Bean
-    public JavaMailSenderImpl javaMailSenderImpl() {
-        final JavaMailSenderImpl mailSenderImpl = new JavaMailSenderImpl();
-
-        try {
-            mailSenderImpl.setHost(env.getRequiredProperty("smtp.host"));
-            mailSenderImpl.setPort(env.getRequiredProperty("smtp.port", Integer.class));
-            mailSenderImpl.setProtocol(env.getRequiredProperty("smtp.protocol"));
-            mailSenderImpl.setUsername(env.getRequiredProperty("smtp.username"));
-            mailSenderImpl.setPassword(env.getRequiredProperty("smtp.password"));
-        } catch (IllegalStateException ise) {
-            LOGGER.error("Could not resolve email.properties.  See email.properties.sample");
-            throw ise;
-        }
-        final Properties javaMailProps = new Properties();
-        javaMailProps.put("mail.smtp.auth", true);
-        javaMailProps.put("mail.smtp.starttls.enable", true);
-        mailSenderImpl.setJavaMailProperties(javaMailProps);
-        return mailSenderImpl;
     }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,14 @@ server.port=8081
 google.recaptcha.key.site=6LfaHiITAAAAAAgZBHl4ZUZAYk5RlOYTr6m2N34X
 google.recaptcha.key.secret=6LfaHiITAAAAANpDTA_Zflwib95IhDqg2SNRLt4U
 
+################### JavaMail Configuration ##########################
+support.email=eugen@baeldung.com
+spring.mail.host=email-smtp.us-east-1.amazonaws.com
+spring.mail.port=465
+spring.mail.protocol=smtps
+spring.mail.username=AKIAJIKXZAQFFJDXI4VQ
+spring.mail.password=
+spring.mail.properties.mail.transport.protocol=smtps
+spring.mail.properties.mail.smtps.auth=true
+spring.mail.properties.mail.smtps.starttls.enable=true
+spring.mail.properties.mail.smtps.timeout=2000


### PR DESCRIPTION
Earlier we are manually creating JavaMailSenderImpl Bean as we are using
spring-boot, let spring-boot create bean for us, to do this we need to
create property values in [application.properties](http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-email) 