### PR TITLE
Upgrade to spring boot release 1.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.4.3.RELEASE</version>
+		<version>1.5.1.RELEASE</version>
 	</parent>
 
 	<dependencies>


### PR DESCRIPTION
If we want to change loggers level at runtime we can use this version, hence upgrading to 1.5.1