### PR TITLE
Compare role name to correct variable in equals method

### DIFF
--- a/src/main/java/org/baeldung/persistence/model/Role.java
+++ b/src/main/java/org/baeldung/persistence/model/Role.java
@@ -89,7 +89,7 @@ public class Role {
             return false;
         }
         final Role role = (Role) obj;
-        if (!role.equals(role.name)) {
+        if (!name.equals(role.name)) {
             return false;
         }
         return true;


### PR DESCRIPTION
Corrected a small typo in the `equals()` method for the `Role` model class.