### PR TITLE
redirecting to a new page if the user is a manager

### DIFF
--- a/src/main/java/com/baeldung/security/MySimpleUrlAuthenticationSuccessHandler.java
+++ b/src/main/java/com/baeldung/security/MySimpleUrlAuthenticationSuccessHandler.java
@@ -80,34 +80,25 @@ public class MySimpleUrlAuthenticationSuccessHandler implements AuthenticationSu
     }
 
     protected String determineTargetUrl(final Authentication authentication) {
-        boolean isUser = false;
-        boolean isAdmin = false;
-        final Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
-        for (final GrantedAuthority grantedAuthority : authorities) {
-            if (grantedAuthority.getAuthority().equals("READ_PRIVILEGE")) {
-                isUser = true;
-            } else if (grantedAuthority.getAuthority().equals("WRITE_PRIVILEGE")) {
-                isAdmin = true;
-                isUser = false;
-                break;
-            }
-        }
-        if (isUser) {
-        	 String username;
-             if (authentication.getPrincipal() instanceof User) {
-             	username = ((User)authentication.getPrincipal()).getEmail();
-             }
-             else {
-             	username = authentication.getName();
-             }
 
-            return "/homepage.html?user="+username;
-        } else if (isAdmin) {
-            return "/console";
-        } else {
+        UserType userType = UserType.findUserType(authentication.getAuthorities());
+
+        if (userType == null) {
             throw new IllegalStateException();
         }
+
+        String username;
+        if (authentication.getPrincipal() instanceof User) {
+            username = ((User)authentication.getPrincipal()).getEmail();
+        }
+        else {
+            username = authentication.getName();
+        }
+        return userType.getHomePage(username);
     }
+
+
+
 
     protected void clearAuthenticationAttributes(final HttpServletRequest request) {
         final HttpSession session = request.getSession(false);

--- a/src/main/java/com/baeldung/security/UserType.java
+++ b/src/main/java/com/baeldung/security/UserType.java
@@ -1,0 +1,60 @@
+package com.baeldung.security;
+
+import com.baeldung.persistence.model.User;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+enum UserType {
+
+    USER {
+        @Override
+        public String getHomePage(String username) {
+            return "/homepage.html?user="+username;
+        }
+    },
+    ADMIN {
+        @Override
+        public String getHomePage(String username) {
+            return "/console";
+        }
+    },
+    MANAGER {
+        @Override
+        public String getHomePage(String username) {
+            return "/management";
+        }
+    };
+
+
+    public abstract String getHomePage(String username) ;
+
+
+    public static UserType findUserType(Collection<? extends GrantedAuthority> authorities) {
+        boolean admin = false;
+        boolean manager = false;
+        boolean user = false;
+        for (final GrantedAuthority grantedAuthority : authorities) {
+            if (grantedAuthority.getAuthority().equals("READ_PRIVILEGE")) {
+                user = true;
+            }
+            if (grantedAuthority.getAuthority().equals("WRITE_PRIVILEGE")) {
+                admin = true;
+            }
+            else if (grantedAuthority.getAuthority().equals("MANAGEMENT_PRIVILEGE")) {
+                manager = true;
+            }
+        }
+        if (manager) {
+            return MANAGER;
+        }
+        else if (admin) {
+            return ADMIN;
+        }
+        else if (user) {
+            return USER;
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/com/baeldung/spring/SetupDataLoader.java
+++ b/src/main/java/com/baeldung/spring/SetupDataLoader.java
@@ -48,15 +48,21 @@ public class SetupDataLoader implements ApplicationListener<ContextRefreshedEven
         final Privilege readPrivilege = createPrivilegeIfNotFound("READ_PRIVILEGE");
         final Privilege writePrivilege = createPrivilegeIfNotFound("WRITE_PRIVILEGE");
         final Privilege passwordPrivilege = createPrivilegeIfNotFound("CHANGE_PASSWORD_PRIVILEGE");
+        final Privilege managementPrivilege = createPrivilegeIfNotFound("MANAGEMENT_PRIVILEGE");
 
         // == create initial roles
-        final List<Privilege> adminPrivileges = new ArrayList<>(Arrays.asList(readPrivilege, writePrivilege, passwordPrivilege));
+        final List<Privilege> adminPrivileges = new ArrayList<>(Arrays.asList(readPrivilege, writePrivilege, passwordPrivilege, managementPrivilege));
+        final List<Privilege> managementPrivileges = new ArrayList<>(Arrays.asList(readPrivilege, writePrivilege, managementPrivilege));
         final List<Privilege> userPrivileges = new ArrayList<>(Arrays.asList(readPrivilege, passwordPrivilege));
+
         final Role adminRole = createRoleIfNotFound("ROLE_ADMIN", adminPrivileges);
+        final Role managerRole = createRoleIfNotFound("ROLE_MANAGER", managementPrivileges);
         createRoleIfNotFound("ROLE_USER", userPrivileges);
+
 
         // == create initial user
         createUserIfNotFound("test@test.com", "Test", "Test", "test", new ArrayList<>(Arrays.asList(adminRole)));
+        createUserIfNotFound("manager@test.com", "Manager", "Test", "test", new ArrayList<>(Arrays.asList(managerRole)));
 
         alreadySetup = true;
     }

--- a/src/main/java/com/baeldung/web/controller/RegistrationController.java
+++ b/src/main/java/com/baeldung/web/controller/RegistrationController.java
@@ -90,6 +90,21 @@ public class RegistrationController {
         return new ModelAndView("console", model);
     }
 
+    @GetMapping("/management")
+    public ModelAndView management(final HttpServletRequest request, final ModelMap model, @RequestParam("messageKey") final Optional<String> messageKey) {
+
+        Locale locale = request.getLocale();
+        messageKey.ifPresent( key -> {
+                    String message = messages.getMessage(key, null, locale);
+                    model.addAttribute("message", message);
+                }
+        );
+
+        return new ModelAndView("management", model);
+    }
+
+
+
     @GetMapping("/badUser")
     public ModelAndView badUser(final HttpServletRequest request, final ModelMap model, @RequestParam("messageKey" ) final Optional<String> messageKey, @RequestParam("expired" ) final Optional<String> expired, @RequestParam("token" ) final Optional<String> token) {
 

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -45,6 +45,7 @@ label.pages.home.message=Welcome Home
 label.pages.users.message=View Logged In Users
 label.pages.users.sessionregistry.message=View Logged In Users from SessionRegistry
 label.pages.admin.message=Welcome Admin
+label.pages.manager.message=Welcome Manager
 label.pages.user.message=Welcome User
 label.successRegister.title=Registration Success
 label.badUser.title=Invalid Link

--- a/src/main/resources/messages_es_ES.properties
+++ b/src/main/resources/messages_es_ES.properties
@@ -42,6 +42,7 @@ label.pages.admin=Administrador
 label.pages.home.title=Inicio
 label.pages.home.message=Bienveni@ a Casa
 label.pages.admin.message=Bienvenid@ Admin
+label.pages.manager.message=Bienvenid@ Gerente
 label.pages.user.message=Bienvenid@ Usuari@
 label.successRegister.title=Registro Exitoso
 label.badUser.title=Enlace Invalido

--- a/src/main/resources/templates/management.html
+++ b/src/main/resources/templates/management.html
@@ -1,0 +1,23 @@
+<html>
+
+<head>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css"/>
+    <title th:utext="#{label.pages.home.title}"></title>
+</head>
+<body>
+<nav class="navbar navbar-default">
+    <div class="container-fluid">
+        <div class="navbar-header">
+            <a class="navbar-brand" th:href="@{/homepage.html}" th:utext="#{label.pages.home.title}">home</a>
+        </div>
+        <ul class="nav navbar-nav navbar-right">
+            <li><a th:href="@{/logout}" th:utext="#{label.pages.logout}">logout</a> </li>
+        </ul>
+    </div>
+</nav>
+
+<div class="container">
+    <h1 sec:authorize="hasAuthority('MANAGEMENT_PRIVILEGE')" th:utext="#{label.pages.manager.message}">management</h1>
+</div>
+</body>
+</html>


### PR DESCRIPTION
This change introduces a new kind of user, which is a manager. As such, the logic of how to decide the type of user got refactored into an enum called UserType. This enum contains a static method that guesses the type of user based on its privileges and then returns the right type of User (or null if it is unable to find out). 

When the user is a manager, the system redirects to a new page, represented by the template management.html. 