### PR TITLE
Fix non-public methods should not be @Transactional

### DIFF
--- a/src/main/java/com/baeldung/spring/SetupDataLoader.java
+++ b/src/main/java/com/baeldung/spring/SetupDataLoader.java
@@ -62,7 +62,7 @@ public class SetupDataLoader implements ApplicationListener<ContextRefreshedEven
     }
 
     @Transactional
-    Privilege createPrivilegeIfNotFound(final String name) {
+    public Privilege createPrivilegeIfNotFound(final String name) {
         Privilege privilege = privilegeRepository.findByName(name);
         if (privilege == null) {
             privilege = new Privilege(name);
@@ -72,7 +72,7 @@ public class SetupDataLoader implements ApplicationListener<ContextRefreshedEven
     }
 
     @Transactional
-    Role createRoleIfNotFound(final String name, final Collection<Privilege> privileges) {
+    public Role createRoleIfNotFound(final String name, final Collection<Privilege> privileges) {
         Role role = roleRepository.findByName(name);
         if (role == null) {
             role = new Role(name);
@@ -83,7 +83,7 @@ public class SetupDataLoader implements ApplicationListener<ContextRefreshedEven
     }
 
     @Transactional
-    User createUserIfNotFound(final String email, final String firstName, final String lastName, final String password, final Collection<Role> roles) {
+    public User createUserIfNotFound(final String email, final String firstName, final String lastName, final String password, final Collection<Role> roles) {
         User user = userRepository.findByEmail(email);
         if (user == null) {
             user = new User();


### PR DESCRIPTION
Hi!

I've recently checked your project with SonarQube as a university task. For extra credits I need to do a pull request that will get merged. I put down below all the details about the bug I found. 

Hope it hepls!

![image](https://user-images.githubusercontent.com/94064021/173412075-bef0511d-51e5-4d33-85ab-59b6b7ed4067.png)

I found this bug in src/main/java/com/baeldung/spring/SetupDataLoader.java on three diferent methods:
- createPrivilegeIfNotFound
- createRoleIfNotFound
- createUserIfNotFound

_Why is this an isssue?_

**Non-public methods should not be "@Transactional"**

Marking a non-public method @Transactional is both useless and misleading because Spring doesn’t "see" non-public methods, and so makes no provision for their proper invocation. Nor does Spring make provision for the methods invoked by the method it called.

Therefore marking a private method, for instance, @Transactional can only result in a runtime error or exception if the method is actually written to be @Transactional.

Have a great one!