### PR TITLE
Changes to add manager role and privilege

### DIFF
--- a/src/main/java/com/baeldung/security/CustomRememberMeServices.java
+++ b/src/main/java/com/baeldung/security/CustomRememberMeServices.java
@@ -16,7 +16,6 @@ import org.springframework.security.core.authority.mapping.NullAuthoritiesMapper
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
-import org.springframework.security.web.authentication.rememberme.InMemoryTokenRepositoryImpl;
 import org.springframework.security.web.authentication.rememberme.PersistentRememberMeToken;
 import org.springframework.security.web.authentication.rememberme.PersistentTokenBasedRememberMeServices;
 import org.springframework.security.web.authentication.rememberme.PersistentTokenRepository;

--- a/src/main/java/com/baeldung/security/MySimpleUrlAuthenticationSuccessHandler.java
+++ b/src/main/java/com/baeldung/security/MySimpleUrlAuthenticationSuccessHandler.java
@@ -99,7 +99,7 @@ public class MySimpleUrlAuthenticationSuccessHandler implements AuthenticationSu
                 break;
             }
         }
-        if (isUser) {
+        if (isUser || isManager) {
         	 String username;
              if (authentication.getPrincipal() instanceof User) {
              	username = ((User)authentication.getPrincipal()).getEmail();
@@ -111,9 +111,7 @@ public class MySimpleUrlAuthenticationSuccessHandler implements AuthenticationSu
             return "/homepage.html?user="+username;
         } else if (isAdmin) {
             return "/console";
-        } else if (isManager) {
-            return "/management";
-        }else {
+        } else {
             throw new IllegalStateException();
         }
     }

--- a/src/main/java/com/baeldung/security/MySimpleUrlAuthenticationSuccessHandler.java
+++ b/src/main/java/com/baeldung/security/MySimpleUrlAuthenticationSuccessHandler.java
@@ -20,6 +20,8 @@ import javax.servlet.http.HttpSession;
 import java.io.IOException;
 import java.util.Collection;
 
+import static com.baeldung.util.AppConstants.*;
+
 @Component("myAuthenticationSuccessHandler")
 public class MySimpleUrlAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
     private final Logger logger = LoggerFactory.getLogger(getClass());
@@ -82,13 +84,18 @@ public class MySimpleUrlAuthenticationSuccessHandler implements AuthenticationSu
     protected String determineTargetUrl(final Authentication authentication) {
         boolean isUser = false;
         boolean isAdmin = false;
+        boolean isManager = false;
         final Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
         for (final GrantedAuthority grantedAuthority : authorities) {
-            if (grantedAuthority.getAuthority().equals("READ_PRIVILEGE")) {
+            if (grantedAuthority.getAuthority().equals(READ_PRIVILEGE)) {
                 isUser = true;
-            } else if (grantedAuthority.getAuthority().equals("WRITE_PRIVILEGE")) {
+            } else if (grantedAuthority.getAuthority().equals(WRITE_PRIVILEGE)) {
                 isAdmin = true;
                 isUser = false;
+                break;
+            } else if (grantedAuthority.getAuthority().equals(MANAGE_PRIVILEGE)) {
+                isManager = true;
+                isAdmin = isUser = false;
                 break;
             }
         }
@@ -104,7 +111,9 @@ public class MySimpleUrlAuthenticationSuccessHandler implements AuthenticationSu
             return "/homepage.html?user="+username;
         } else if (isAdmin) {
             return "/console";
-        } else {
+        } else if (isManager) {
+            return "/management";
+        }else {
             throw new IllegalStateException();
         }
     }

--- a/src/main/java/com/baeldung/spring/AppConfig.java
+++ b/src/main/java/com/baeldung/spring/AppConfig.java
@@ -3,9 +3,14 @@ package com.baeldung.spring;
 import com.baeldung.security.ActiveUserStore;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.GlobalMethodSecurityConfiguration;
+import org.thymeleaf.templatemode.TemplateMode;
+import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
 
 @Configuration
-public class AppConfig {
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+public class AppConfig extends GlobalMethodSecurityConfiguration{
     // beans
 
     @Bean
@@ -13,4 +18,17 @@ public class AppConfig {
         return new ActiveUserStore();
     }
 
+    @Bean
+    public ClassLoaderTemplateResolver managementTemplateResolver() {
+        ClassLoaderTemplateResolver managementTemplateResolver = new ClassLoaderTemplateResolver();
+        managementTemplateResolver.setPrefix("private/");
+        managementTemplateResolver.setSuffix(".html");
+        managementTemplateResolver.setTemplateMode(TemplateMode.HTML);
+        managementTemplateResolver.setCharacterEncoding("UTF-8");
+        managementTemplateResolver.setOrder(1);
+        managementTemplateResolver.setCheckExistence(true);
+        return managementTemplateResolver;
+    }
+    
+    
 }

--- a/src/main/java/com/baeldung/spring/MvcConfig.java
+++ b/src/main/java/com/baeldung/spring/MvcConfig.java
@@ -58,6 +58,8 @@ public class MvcConfig implements WebMvcConfigurer {
         registry.addViewController("/changePassword.html");
         registry.addViewController("/users.html");
         registry.addViewController("/qrcode.html");
+        registry.addViewController("/management.html");
+        registry.addViewController("/accessDenied.html");
     }
 
     @Override

--- a/src/main/java/com/baeldung/spring/SecSecurityConfig.java
+++ b/src/main/java/com/baeldung/spring/SecSecurityConfig.java
@@ -1,12 +1,8 @@
 package com.baeldung.spring;
 
-import com.baeldung.persistence.dao.UserRepository;
-import com.baeldung.security.CustomRememberMeServices;
-import com.baeldung.security.google2fa.CustomAuthenticationProvider;
-import com.baeldung.security.google2fa.CustomWebAuthenticationDetailsSource;
-import com.baeldung.security.location.DifferentLocationChecker;
-import com.maxmind.geoip2.DatabaseReader;
-import com.maxmind.geoip2.exception.GeoIp2Exception;
+import java.io.File;
+import java.io.IOException;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -32,8 +28,12 @@ import org.springframework.security.web.authentication.logout.LogoutSuccessHandl
 import org.springframework.security.web.authentication.rememberme.InMemoryTokenRepositoryImpl;
 import org.springframework.security.web.session.HttpSessionEventPublisher;
 
-import java.io.File;
-import java.io.IOException;
+import com.baeldung.security.CustomRememberMeServices;
+import com.baeldung.security.google2fa.CustomAuthenticationProvider;
+import com.baeldung.security.google2fa.CustomWebAuthenticationDetailsSource;
+import com.baeldung.security.location.DifferentLocationChecker;
+import com.maxmind.geoip2.DatabaseReader;
+import com.maxmind.geoip2.exception.GeoIp2Exception;
 
 @ComponentScan(basePackages = { "com.baeldung.security" })
 // @ImportResource({ "classpath:webSecurityConfig.xml" })
@@ -54,9 +54,6 @@ public class SecSecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Autowired
     private CustomWebAuthenticationDetailsSource authenticationDetailsSource;
-
-    @Autowired
-    private UserRepository userRepository;
 
     @Autowired
     private DifferentLocationChecker differentLocationChecker;

--- a/src/main/java/com/baeldung/spring/SetupDataLoader.java
+++ b/src/main/java/com/baeldung/spring/SetupDataLoader.java
@@ -18,6 +18,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.baeldung.util.AppConstants.*;
+
 @Component
 public class SetupDataLoader implements ApplicationListener<ContextRefreshedEvent> {
 
@@ -45,18 +47,23 @@ public class SetupDataLoader implements ApplicationListener<ContextRefreshedEven
         }
 
         // == create initial privileges
-        final Privilege readPrivilege = createPrivilegeIfNotFound("READ_PRIVILEGE");
-        final Privilege writePrivilege = createPrivilegeIfNotFound("WRITE_PRIVILEGE");
-        final Privilege passwordPrivilege = createPrivilegeIfNotFound("CHANGE_PASSWORD_PRIVILEGE");
+        final Privilege readPrivilege = createPrivilegeIfNotFound(READ_PRIVILEGE);
+        final Privilege writePrivilege = createPrivilegeIfNotFound(WRITE_PRIVILEGE);
+        final Privilege managePrivilege = createPrivilegeIfNotFound(MANAGE_PRIVILEGE);
+        final Privilege passwordPrivilege = createPrivilegeIfNotFound(CHANGE_PASSWORD_PRIVILEGE);
 
         // == create initial roles
         final List<Privilege> adminPrivileges = new ArrayList<>(Arrays.asList(readPrivilege, writePrivilege, passwordPrivilege));
+        final List<Privilege> managerPrivileges = new ArrayList<>(Arrays.asList(readPrivilege, writePrivilege, managePrivilege, passwordPrivilege));
         final List<Privilege> userPrivileges = new ArrayList<>(Arrays.asList(readPrivilege, passwordPrivilege));
-        final Role adminRole = createRoleIfNotFound("ROLE_ADMIN", adminPrivileges);
-        createRoleIfNotFound("ROLE_USER", userPrivileges);
+        final Role adminRole = createRoleIfNotFound(ROLE_ADMIN, adminPrivileges);
+        final Role managerRole = createRoleIfNotFound(ROLE_MANAGER, managerPrivileges);
+        final Role userRole = createRoleIfNotFound(ROLE_USER, userPrivileges);
 
         // == create initial user
-        createUserIfNotFound("test@test.com", "Test", "Test", "test", new ArrayList<>(Arrays.asList(adminRole)));
+        createUserIfNotFound("admin@test.com", "Admin", "Test", "a", new ArrayList<>(Arrays.asList(adminRole)));
+        createUserIfNotFound("manager@test.com", "Manager", "Test", "m", new ArrayList<>(Arrays.asList(managerRole)));
+        createUserIfNotFound("user@test.com", "User", "Test", "u", new ArrayList<>(Arrays.asList(userRole)));
 
         alreadySetup = true;
     }

--- a/src/main/java/com/baeldung/spring/SetupDataLoader.java
+++ b/src/main/java/com/baeldung/spring/SetupDataLoader.java
@@ -61,7 +61,7 @@ public class SetupDataLoader implements ApplicationListener<ContextRefreshedEven
         final Role userRole = createRoleIfNotFound(ROLE_USER, userPrivileges);
 
         // == create initial user
-        createUserIfNotFound("admin@test.com", "Admin", "Test", "a", new ArrayList<>(Arrays.asList(adminRole)));
+        createUserIfNotFound("test@test.com", "Admin", "Test", "test", new ArrayList<>(Arrays.asList(adminRole)));
         createUserIfNotFound("manager@test.com", "Manager", "Test", "m", new ArrayList<>(Arrays.asList(managerRole)));
         createUserIfNotFound("user@test.com", "User", "Test", "u", new ArrayList<>(Arrays.asList(userRole)));
 

--- a/src/main/java/com/baeldung/util/AppConstants.java
+++ b/src/main/java/com/baeldung/util/AppConstants.java
@@ -1,0 +1,12 @@
+package com.baeldung.util;
+
+public class AppConstants {
+    public static final String READ_PRIVILEGE = "READ_PRIVILEGE";
+    public static final String WRITE_PRIVILEGE = "WRITE_PRIVILEGE";
+    public static final String MANAGE_PRIVILEGE = "MANAGE_PRIVILEGE";
+    public static final String CHANGE_PASSWORD_PRIVILEGE = "CHANGE_PASSWORD_PRIVILEGE";
+
+    public static final String ROLE_ADMIN = "ROLE_ADMIN";
+    public static final String ROLE_MANAGER = "ROLE_MANAGER";
+    public static final String ROLE_USER = "ROLE_USER";
+}

--- a/src/main/java/com/baeldung/web/controller/ManagementController.java
+++ b/src/main/java/com/baeldung/web/controller/ManagementController.java
@@ -1,0 +1,17 @@
+package com.baeldung.web.controller;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.ModelAndView;
+
+@RestController
+public class ManagementController {
+    
+    @GetMapping("/management")
+    @PreAuthorize("hasRole('ROLE_MANAGER')")
+    public ModelAndView management(final ModelMap model) {
+        return new ModelAndView("management", model);
+    }
+}

--- a/src/main/java/com/baeldung/web/controller/RegistrationController.java
+++ b/src/main/java/com/baeldung/web/controller/RegistrationController.java
@@ -1,35 +1,5 @@
 package com.baeldung.web.controller;
 
-import com.baeldung.persistence.model.Privilege;
-import com.baeldung.persistence.model.Role;
-import com.baeldung.persistence.model.User;
-import com.baeldung.registration.OnRegistrationCompleteEvent;
-import com.baeldung.security.ISecurityUserService;
-import com.baeldung.service.IUserService;
-import com.baeldung.web.dto.UserDto;
-import com.baeldung.web.util.GenericResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.context.MessageSource;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Controller;
-import org.springframework.ui.ModelMap;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.servlet.ModelAndView;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.validation.Valid;
 import java.io.UnsupportedEncodingException;
 import java.util.Collection;
 import java.util.List;
@@ -37,10 +7,32 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.MessageSource;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.ModelAndView;
+
+import com.baeldung.persistence.model.Privilege;
+import com.baeldung.persistence.model.Role;
+import com.baeldung.persistence.model.User;
+import com.baeldung.security.ISecurityUserService;
+import com.baeldung.service.IUserService;
+
 @Controller
 public class RegistrationController {
-
-    private final Logger LOGGER = LoggerFactory.getLogger(getClass());
 
     @Autowired
     private IUserService userService;
@@ -177,17 +169,4 @@ public class RegistrationController {
         Authentication authentication = new UsernamePasswordAuthenticationToken(user, null, authorities);
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
-
-    private String getAppUrl(HttpServletRequest request) {
-        return "http://" + request.getServerName() + ":" + request.getServerPort() + request.getContextPath();
-    }
-
-    private final String getClientIP(HttpServletRequest request) {
-        final String xfHeader = request.getHeader("X-Forwarded-For");
-        if (xfHeader == null) {
-            return request.getRemoteAddr();
-        }
-        return xfHeader.split(",")[0];
-    }
-
 }

--- a/src/main/java/com/baeldung/web/error/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/com/baeldung/web/error/RestResponseEntityExceptionHandler.java
@@ -1,18 +1,25 @@
 package com.baeldung.web.error;
 
+import com.baeldung.persistence.model.User;
 import com.baeldung.web.util.GenericResponse;
+
+import javax.servlet.http.HttpServletRequest;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.MessageSource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mail.MailAuthenticationException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @ControllerAdvice
@@ -87,6 +94,13 @@ public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionH
         logger.error("500 Status Code", ex);
         final GenericResponse bodyOfResponse = new GenericResponse(messages.getMessage("message.unavailableReCaptcha", null, request.getLocale()), "InvalidReCaptcha");
         return handleExceptionInternal(ex, bodyOfResponse, new HttpHeaders(), HttpStatus.INTERNAL_SERVER_ERROR, request);
+    }
+    
+    @ExceptionHandler({ AccessDeniedException.class })
+    public ModelAndView handleAccessDenied(final RuntimeException ex, final WebRequest request, final HttpServletRequest httpRequest) {
+    	final User user = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        logger.warn("User "+ user.getFirstName() +" attempted to access unauthorized URL "+ httpRequest.getRequestURI());
+        return new ModelAndView("accessDenied");
     }
 
     @ExceptionHandler({ Exception.class })

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -100,3 +100,4 @@ message.login.notification.ip=IP Address:
 label.pages.access.denied.title=Access Denied
 label.pages.access.denied.message=Access denied, please go back to home page
 label.pages.management=Management
+label.pages.management.home.message=Management Home

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -97,3 +97,5 @@ auth.message.unusual.location = You are trying to login from unusual location, c
 message.login.notification.deviceDetails=Device details:
 message.login.notification.location=Location:
 message.login.notification.ip=IP Address:
+label.pages.access.denied.title=Access Denied
+label.pages.access.denied.message=Access denied, please go back to home page

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -99,3 +99,4 @@ message.login.notification.location=Location:
 message.login.notification.ip=IP Address:
 label.pages.access.denied.title=Access Denied
 label.pages.access.denied.message=Access denied, please go back to home page
+label.pages.management=Management

--- a/src/main/resources/messages_es_ES.properties
+++ b/src/main/resources/messages_es_ES.properties
@@ -92,3 +92,5 @@ message.login.notification.location=Ubicacion:
 message.login.notification.ip=Direccion IP:
 label.pages.access.denied.title=Acceso denegado
 label.pages.access.denied.message=Acceso denegado, vuelve a la página de inicio
+label.pages.management=Administración
+label.pages.management.home.message=Casa de Administración

--- a/src/main/resources/messages_es_ES.properties
+++ b/src/main/resources/messages_es_ES.properties
@@ -90,3 +90,5 @@ auth.message.unusual.location = Estï¿½s intentando iniciar sesiï¿½n desde una ub
 message.login.notification.deviceDetails=Detalles del dispositivo:
 message.login.notification.location=Ubicacion:
 message.login.notification.ip=Direccion IP:
+label.pages.access.denied.title=Acceso denegado
+label.pages.access.denied.message=Acceso denegado, vuelve a la página de inicio

--- a/src/main/resources/private/management.html
+++ b/src/main/resources/private/management.html
@@ -1,0 +1,24 @@
+<html>
+
+<head>
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css"/>
+<title th:utext="#{label.pages.home.title}">home</title>
+</head>
+<body>
+<nav class="navbar navbar-default">
+  <div class="container-fluid">
+    <div class="navbar-header">
+      <a class="navbar-brand" href="#" th:utext="#{label.pages.home.title}">home</a>
+    </div>
+      <ul class="nav navbar-nav navbar-right">
+        <li><a th:href="@{/logout}" th:utext="#{label.pages.logout}">logout</a></li>
+      </ul>
+  </div>
+</nav>
+    <div class="container">
+            <h1 th:utext="#{label.pages.home.message}">home</h1>
+    </div>
+</body>
+
+</html>
+

--- a/src/main/resources/private/management.html
+++ b/src/main/resources/private/management.html
@@ -8,7 +8,7 @@
 <nav class="navbar navbar-default">
   <div class="container-fluid">
     <div class="navbar-header">
-      <a class="navbar-brand" href="#" th:utext="#{label.pages.home.title}">home</a>
+      <a class="navbar-brand" href="/home.html" th:utext="#{label.pages.home.title}">home</a>
     </div>
       <ul class="nav navbar-nav navbar-right">
         <li><a th:href="@{/logout}" th:utext="#{label.pages.logout}">logout</a></li>
@@ -16,7 +16,7 @@
   </div>
 </nav>
     <div class="container">
-            <h1 th:utext="#{label.pages.home.message}">home</h1>
+            <h1 th:utext="#{label.pages.management.home.message}">Management home</h1>
     </div>
 </body>
 

--- a/src/main/resources/templates/accessDenied.html
+++ b/src/main/resources/templates/accessDenied.html
@@ -1,0 +1,23 @@
+<html>
+
+<head>
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css"/>
+<title th:utext="#{label.pages.access.denied.title}">Access Denied</title>
+</head>
+<body>
+<nav class="navbar navbar-default">
+  <div class="container-fluid">
+    <div class="navbar-header">
+      <a class="navbar-brand" th:href="@{/home.html}" th:utext="#{label.pages.home.title}">home</a>
+    </div>
+      <ul class="nav navbar-nav navbar-right">
+        <li><a th:href="@{/logout}" th:utext="#{label.pages.logout}">logout</a></li>
+      </ul>
+  </div>
+</nav>
+    <div class="container">
+       <h1 th:utext="#{label.pages.access.denied.message}">Access denied, please go back to home page</h1>
+    </div>
+</body>
+
+</html>

--- a/src/main/resources/templates/homepage.html
+++ b/src/main/resources/templates/homepage.html
@@ -24,6 +24,8 @@
 	     
 	    <a class="btn btn-default" th:href="@{/admin.html}" th:utext="#{label.pages.admin}">admin</a>
 		<br /> <br />
+		<a sec:authorize="hasAuthority('MANAGE_PRIVILEGE')" class="btn btn-default" th:href="@{/management}" th:utext="#{label.pages.management}">management</a>
+		<br /> <br />
 	    <a th:href="@{/loggedUsers}" th:utext="#{label.pages.users.message}">View logged in users</a>
 		<br />	    
 	    <a th:href="@{/loggedUsersFromSessionRegistry}" th:utext="#{label.pages.users.sessionregistry.message}">View logged in users</a>

--- a/src/test/java/com/baeldung/test/IntegrationSuite.java
+++ b/src/test/java/com/baeldung/test/IntegrationSuite.java
@@ -14,7 +14,8 @@ import org.junit.runner.RunWith;
     UserServiceIntegrationTest.class,
     UserIntegrationTest.class,
     SpringSecurityRolesIntegrationTest.class,
-    LocalizationIntegrationTest.class
+    LocalizationIntegrationTest.class,
+    ManagerRoleIntegrationTest.class
 })// @formatter:on
 public class IntegrationSuite {
   //

--- a/src/test/java/com/baeldung/test/ManagerRoleIntegrationTest.java
+++ b/src/test/java/com/baeldung/test/ManagerRoleIntegrationTest.java
@@ -1,0 +1,124 @@
+package com.baeldung.test;
+
+import static com.baeldung.util.AppConstants.MANAGE_PRIVILEGE;
+import static com.baeldung.util.AppConstants.ROLE_MANAGER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.baeldung.Application;
+import com.baeldung.persistence.dao.PrivilegeRepository;
+import com.baeldung.persistence.dao.RoleRepository;
+import com.baeldung.persistence.dao.UserRepository;
+import com.baeldung.persistence.model.Privilege;
+import com.baeldung.persistence.model.Role;
+import com.baeldung.persistence.model.User;
+import com.baeldung.spring.TestDbConfig;
+import com.baeldung.spring.TestIntegrationConfig;
+
+import io.restassured.RestAssured;
+import io.restassured.authentication.FormAuthConfig;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = { Application.class, TestDbConfig.class, TestIntegrationConfig.class }, webEnvironment = WebEnvironment.RANDOM_PORT)
+public class ManagerRoleIntegrationTest {
+
+	@Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RoleRepository roleRepository;
+
+    @Autowired
+    private PrivilegeRepository privilegeRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+    
+    @Value("${local.server.port}")
+    int port;
+
+    private User user;
+    private Role role;
+    private Privilege privilege;
+    private FormAuthConfig formConfig;
+    
+    @BeforeEach
+    public void init() {
+        RestAssured.port = port;
+        RestAssured.baseURI = "http://localhost";
+        formConfig = new FormAuthConfig("/login", "username", "password");
+    }
+	
+	@Test
+	public void testManagementUrlByManagerUser() {
+		
+		// Create user with managerial role and privileges
+		privilege = new Privilege(MANAGE_PRIVILEGE);
+        privilegeRepository.save(privilege);
+
+        role = new Role(ROLE_MANAGER);
+        role.setPrivileges(Arrays.asList(privilege));
+        roleRepository.save(role);
+
+        user = new User();
+        user.setFirstName("John");
+        user.setLastName("Doe");
+        user.setPassword(passwordEncoder.encode("123"));
+        user.setEmail("john@doe.com");
+        user.setRoles(Arrays.asList(role));
+        user.setEnabled(true);
+        userRepository.save(user);
+        
+        final RequestSpecification request = RestAssured.given().auth().form("john@doe.com", "123", formConfig);
+
+        final Map<String, String> params = new HashMap<>();
+        params.put("password", "test");
+
+        final Response response = request.with().params(params).get("/management");
+        assertEquals(200, response.statusCode());
+	}
+	
+	@Test
+	public void testManagementUrlByNonManagerUser() {
+		
+		// Create user with managerial role and privileges
+		privilege = new Privilege("TEST_PRIVILEGE");
+        privilegeRepository.save(privilege);
+
+        role = new Role("TEST_ROLE");
+        role.setPrivileges(Arrays.asList(privilege));
+        roleRepository.save(role);
+
+        user = new User();
+        user.setFirstName("John");
+        user.setLastName("Doe");
+        user.setPassword(passwordEncoder.encode("123"));
+        user.setEmail("john@doe.com");
+        user.setRoles(Arrays.asList(role));
+        user.setEnabled(true);
+        userRepository.save(user);
+        
+        final RequestSpecification request = RestAssured.given().auth().form("john@doe.com", "123", formConfig);
+
+        final Map<String, String> params = new HashMap<>();
+        params.put("password", "test");
+
+        final Response response = request.with().params(params).get("/management");
+        assertEquals(302, response.statusCode());
+	}
+}

--- a/src/test/java/com/baeldung/test/ManagerRoleIntegrationTest.java
+++ b/src/test/java/com/baeldung/test/ManagerRoleIntegrationTest.java
@@ -119,6 +119,6 @@ public class ManagerRoleIntegrationTest {
         params.put("password", "test");
 
         final Response response = request.with().params(params).get("/management");
-        assertEquals(302, response.statusCode());
+        assertEquals(403, response.statusCode()); // Access Denied HTTP Status
 	}
 }


### PR DESCRIPTION
**Request**

1. Need new manager role and privilege
2. Need to add a dummy user with Manager role
3. Landing page for all Manager should be /Homepage
4. Homepage should have management Button only visible to Manager
5. Button redirects to /management URL
6. /management URL should show management.html located in src/main/resources/private folder
7. /management should only be accessible by Managers
8. when above url is accessed by any other user (different role) should be redirected to /accessDenied.html
9. Log message User xxx attempted to access unauthorised URL xxx in above scenario

**Solution**

1. Added new Privilege and Role named as MANAGE_PRIVILEGE and ROLE_MANAGE respectively in SetupDataLoader.java
2. Added dummy user for all three roles
3. Landing page for Manager is configured in MySimpleUrlAuthenticationSuccessHandler.java
4. Added Management Button with Security check in homepage.html
5. Added Anchor link to button to redirect the user to management URL
6. Management URL will show management.html as coded in ManagementController.java and to access it from custom folder added thyme-leaf config in AppConfig.java
7. `ManagementController.java` method is secured with `preAuthorized` annotation which is enabled with help of Spring's`@EnableGlobalMethodSecurity(prePostEnabled = true)` on AppConfig class, and if another role of user try to access this they will get Access Denied Exception
8. Once we get Access Denied Exception that is being caught by out existing `RestResponseEntityExceptionHandler.java`, hence added a specific method to handle Access Denied Exception which then redirect user to `accessDenied.html`
9. Above Method also check the current user logged in and also check current URL which was attempted to connect and log both in `User xxx attempted to access unauthorised URL xxx` format, and made it generic enough to cater all access denied exception.
10. Also added Integration test to verify Manager Role and its access