### PR TITLE
Make sure application works when deployed to a container also

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,9 @@ target/
 .idea/
 *.iml
 *.iws
+/.apt_generated_tests/
+
+**/META-INF/maven
+**/META-INF/MANIFEST.MF
+
+*.log

--- a/src/main/java/com/baeldung/spring/SecSecurityConfig.java
+++ b/src/main/java/com/baeldung/spring/SecSecurityConfig.java
@@ -150,7 +150,7 @@ public class SecSecurityConfig {
 
     @Bean(name="GeoIPCountry")
     public DatabaseReader databaseReader() throws IOException, GeoIp2Exception {
-        final File resource = new File("src/main/resources/maxmind/GeoLite2-Country.mmdb");
+        final File resource = new File(this.getClass().getClassLoader().getResource("maxmind/GeoLite2-Country.mmdb").getFile());
         return new DatabaseReader.Builder(resource).build();
     }
 

--- a/src/main/webapp/META-INF/MANIFEST.MF
+++ b/src/main/webapp/META-INF/MANIFEST.MF
@@ -1,3 +1,0 @@
-Manifest-Version: 1.0
-Class-Path: 
-


### PR DESCRIPTION
The file GeoLite2-Country.mmdb is not found when the spring-security-registration is deployed to a container.  This fixes that problem and now the app works as a java application or when deployed to a container.  I also removed from SCM the MANIFEST.MF (which is recreated by maven and Eclipse) and added additional files to ignore from SCM.  This will ensure the working copied does not become dirty during build of the application.